### PR TITLE
Cleanup and simplify PrefixFreeTree and encoders

### DIFF
--- a/compressors/huffman_coder.py
+++ b/compressors/huffman_coder.py
@@ -45,7 +45,7 @@ class HuffmanTree(PrefixFreeTree):
         """
         # Lets say we have symbols {1,2,3,4,5,6} with prob {p1, p2,...p6}
         # We first start by initializing a list
-        # [ HuffmanNode(id=3, prob=p3), (HuffmanTree(id=6, prob=p6),  ]
+        # [..., HuffmanNode(id=3, prob=p3), (HuffmanNode(id=6, prob=p6),  ...]
 
         node_list = []
         for a in self.prob_dist.alphabet:
@@ -82,12 +82,16 @@ class HuffmanTree(PrefixFreeTree):
 
 
 class HuffmanEncoder(PrefixFreeEncoder):
+    '''
+    PrefiFreeEncoder already has a encode_block function to encode the symbols once we define a encode_symbol function
+    for the particular compressor.
+    '''
     def __init__(self, prob_dist: ProbabilityDist):
-        tree = HuffmanTree(prob_dist)
-        self.encoding_table = tree.get_encoding_table()
+        self.tree = HuffmanTree(prob_dist)
+        # self.encoding_table = tree.get_encoding_table()
 
     def encode_symbol(self, s):
-        return self.encoding_table[s]
+        return self.tree.encode_symbol(s)
 
 
 class HuffmanDecoder(PrefixFreeDecoder):

--- a/compressors/huffman_coder.py
+++ b/compressors/huffman_coder.py
@@ -4,9 +4,7 @@ import heapq
 from functools import total_ordering
 from compressors.prefix_free_compressors import PrefixFreeTree, PrefixFreeEncoder, PrefixFreeDecoder
 from core.prob_dist import ProbabilityDist
-import unittest
 import numpy as np
-from core.data_block import DataBlock
 from utils.bitarray_utils import BitArray
 from utils.test_utils import get_random_data_block, try_lossless_compression
 from utils.tree_utils import BinaryNode
@@ -17,8 +15,8 @@ from utils.tree_utils import BinaryNode
 class HuffmanNode(BinaryNode):
     """represents a node of the huffman tree
 
-    NOTE: PrefixFreeNode class already has left_child, right_child, id, code fields
-    here by subclassing we add a couple of more fields: prob
+    NOTE: BinaryNode class already has left_child, right_child, id fields
+    here by subclassing we add the field: prob
     """
 
     prob: float = None
@@ -33,7 +31,13 @@ class HuffmanNode(BinaryNode):
 
 
 class HuffmanTree(PrefixFreeTree):
-    def build_tree(self) -> HuffmanNode:
+    def __init__(self, prob_dist: ProbabilityDist):
+        self.prob_dist = prob_dist
+
+        # construct the tree and set the root_node of PrefixFreeTree base class
+        super().__init__(root_node=self.build_huffman_tree())
+
+    def build_huffman_tree(self) -> HuffmanNode:
         """Build the huffman coding tree
 
         1. Sort the prob distribution, combine last two symbols into a single symbol

--- a/compressors/huffman_coder.py
+++ b/compressors/huffman_coder.py
@@ -83,18 +83,23 @@ class HuffmanTree(PrefixFreeTree):
 
 class HuffmanEncoder(PrefixFreeEncoder):
     '''
-    PrefiFreeEncoder already has a encode_block function to encode the symbols once we define a encode_symbol function
+    PrefixFreeEncoder already has a encode_block function to encode the symbols once we define a encode_symbol function
     for the particular compressor.
+    PrefixFreeTree provides encode_symbol given a PrefixFreeTree
     '''
     def __init__(self, prob_dist: ProbabilityDist):
         self.tree = HuffmanTree(prob_dist)
-        # self.encoding_table = tree.get_encoding_table()
 
     def encode_symbol(self, s):
         return self.tree.encode_symbol(s)
 
 
 class HuffmanDecoder(PrefixFreeDecoder):
+    '''
+    PrefixFreeDecoder already has a decode_block function to decode the symbols once we define a decode_symbol function
+    for the particular compressor.
+    PrefixFreeTree provides decode_symbol given a PrefixFreeTree
+    '''
     def __init__(self, prob_dist: ProbabilityDist):
         self.tree = HuffmanTree(prob_dist)
 

--- a/compressors/prefix_free_compressors.py
+++ b/compressors/prefix_free_compressors.py
@@ -8,11 +8,9 @@ useful for implementing any prefix free code
 """
 
 import abc
-from dataclasses import dataclass
 from typing import Mapping, Tuple, Any
 from utils.bitarray_utils import BitArray
 from utils.tree_utils import BinaryNode
-from core.prob_dist import ProbabilityDist
 from core.data_encoder_decoder import DataEncoder, DataDecoder
 from core.data_block import DataBlock
 
@@ -85,16 +83,22 @@ class PrefixFreeDecoder(DataDecoder):
 
 
 class PrefixFreeTree:
-    def __init__(self, prob_dist: ProbabilityDist):
-        """
-        create the prefix free tree
-        """
-        self.prob_dist = prob_dist
-        self.root_node = self.build_tree()
+    """Class representing a Prefix Free Tree
 
-    def get_encoding_table(self):
-        """
-        parse the root node and get the encoding table
+    Any subclassing class needs to set the root_node appropriately
+    """
+
+    def __init__(self, root_node: BinaryNode):
+        self.root_node = root_node
+
+    def print_tree(self):
+        self.root_node.print_node()
+
+    def get_encoding_table(self) -> Mapping[Any, BitArray]:
+        """utility func to get the encoding table based on the prefix-free tree
+
+        Returns:
+            Mapping[Any,BitArray]: the encoding_array dict
         """
         encoding_table = {}
 
@@ -120,15 +124,6 @@ class PrefixFreeTree:
         # call the parsing function on the root node
         _parse_node(self.root_node, BitArray(""))
         return encoding_table
-
-    def print_tree(self):
-        self.root_node.print_node()
-
-    def build_tree(self) -> BinaryNode:
-        """
-        abstract function -> needs to be implemented by the subclassing class
-        """
-        raise NotImplementedError
 
     def decode_symbol(self, encoded_bitarray):
         """decode each symbol by parsing through the prefix free tree

--- a/utils/test_utils.py
+++ b/utils/test_utils.py
@@ -82,8 +82,8 @@ def try_file_lossless_compression(
 
     Args:
         input_file_path (str): input file path
-        encoder (DataEncoder): encodr object
-        decoder (DataDecoder): decoder objct
+        encoder (DataEncoder): encoder object
+        decoder (DataDecoder): decoder object
     """
     with tempfile.TemporaryDirectory() as tmpdirname:
         encoded_file_path = os.path.join(tmpdirname, "encoded_file.bin")

--- a/utils/tree_utils.py
+++ b/utils/tree_utils.py
@@ -13,10 +13,11 @@ class BinaryNode:
         return (self.left_child is None) and (self.right_child is None)
 
     def _get_lines(self):
-        """internal function to print the tree
+        """
+        internal function to visualize the tree starting from the root node.
 
         Returns:
-            lines, root_node:
+            lines, root_node
         """
 
         # utility function to merge two lists of strings
@@ -114,7 +115,8 @@ class BinaryNode:
         return lines, root_node_loc
 
     def print_node(self):
-        """print the tree from the given node
+        """
+        Print the tree from the root node
 
         returns the lines of the tree, and the line number of the node
         internal function used in recursively printing the node


### PR DESCRIPTION
Based on feedback from @tpulkit: I was thinking of simplifying the `PrefixFreeTree` etc. 
The issue earlier was that there were too many sublcasses, which were making it difficult to understand the code.

Some simplifications: 
- [x] Removed `PrefixFreeNode`.. as it added very less value. (We had added the field "code".. but we really don't need a new field). 
- [x] Moved the function `get_encoding_table` to `PrefixFreeTree` .. as it is really a function of the tree. 
- [x] All prefix-free coders can now only subclass `PrefixFreeEncoder` and `PrefixFreeDecoder`. NO `PrefixFreeTreeEncoder` etc. .. they can however construct define their own tree internally. I thought this increases the transparency, and makes the implemented coders easier to understand. 

Feedback welcome! @tpulkit: If we merge this, you might have to change a few things on your end. It will probably make your life much easier. 