### PR TITLE
delete redundant code

### DIFF
--- a/scl/compressors/arithmetic_coding.py
+++ b/scl/compressors/arithmetic_coding.py
@@ -420,7 +420,7 @@ def test_adaptive_order_k_arithmetic_coding():
     # print newline so it shows up nicely on testing
     print()
 
-    for (model_params, expected_bitrate) in [
+    for model_params, expected_bitrate in [
         (([0, 1, 2], 0), np.log2(3)),
         (([0, 1, 2], 1), np.log2(3)),
         (([0, 1, 2], 2), 1),

--- a/scl/compressors/fano_coder.py
+++ b/scl/compressors/fano_coder.py
@@ -5,6 +5,7 @@ https://en.wikipedia.org/w/index.php?title=Shannon–Fano_coding&oldid=107652002
 
 This document uses Fano coding as described in the wiki article above.
 """
+
 from typing import Any, Tuple
 from scl.utils.bitarray_utils import BitArray
 from scl.utils.test_utils import get_random_data_block, try_lossless_compression

--- a/scl/compressors/fixed_bitwidth_compressor.py
+++ b/scl/compressors/fixed_bitwidth_compressor.py
@@ -2,6 +2,7 @@
 Contains one of the simplest compressors: 
 Fixed Bitwidth compressor -> uses a fixed bitwidth for each symbol
 """
+
 import tempfile
 import os
 from scl.core.data_block import DataBlock

--- a/scl/compressors/huffman_coder.py
+++ b/scl/compressors/huffman_coder.py
@@ -70,12 +70,11 @@ class HuffmanTree(PrefixFreeTree):
         # We are concerned about finding the top two smallest elements from the list
         # Heaps are efficient at such operations O(log(n)) -> push/pop, O(1) -> min val
         node_heap = node_list  # shallow copy
+        # create a min-heap (in-place) from the node list, so that we can get 
+        # the two smallest elements efficiently
         heapq.heapify(node_heap)
 
         while len(node_heap) > 1:
-            # create a min-heap (in-place) from the node list, so that we can get the
-            heapq.heapify(node_heap)
-
             # get the two smallest symbols
             last1 = heapq.heappop(node_heap)
             last2 = heapq.heappop(node_heap)

--- a/scl/compressors/huffman_coder.py
+++ b/scl/compressors/huffman_coder.py
@@ -70,7 +70,7 @@ class HuffmanTree(PrefixFreeTree):
         # We are concerned about finding the top two smallest elements from the list
         # Heaps are efficient at such operations O(log(n)) -> push/pop, O(1) -> min val
         node_heap = node_list  # shallow copy
-        # create a min-heap (in-place) from the node list, so that we can get 
+        # create a min-heap (in-place) from the node list, so that we can get
         # the two smallest elements efficiently
         heapq.heapify(node_heap)
 

--- a/scl/compressors/shannon_coder.py
+++ b/scl/compressors/shannon_coder.py
@@ -29,6 +29,7 @@ d. If the "binary" floating point representation is clear, then the Shannon code
    \left\lceil \log_2 \frac{1}{p_r} \right\rceil $ can be obtained by simply truncating the binary floating point
    representation of $c_r$
 """
+
 from typing import Any, Tuple
 from scl.utils.bitarray_utils import float_to_bitarrays, BitArray
 from scl.utils.test_utils import get_random_data_block, try_lossless_compression

--- a/scl/core/prob_dist.py
+++ b/scl/core/prob_dist.py
@@ -132,7 +132,7 @@ class ProbabilityDistTest(unittest.TestCase):
         sorted_PD = ProbabilityDist.get_sorted_prob_dist(dist, descending=True)
         # initialize to max prob
         prev_symbol_prob = 1
-        for (s, curr_symbol_prob) in sorted_PD.prob_dict.items():
+        for s, curr_symbol_prob in sorted_PD.prob_dict.items():
             assert curr_symbol_prob <= prev_symbol_prob
             prev_symbol_prob = curr_symbol_prob
 


### PR DESCRIPTION
Removes redundant heapify calls within the `build_huffman_tree` function. The `heapq.heappush(node_heap, combined_node)` operation already maintains the heap property, making the initial heapify call in each loop unnecessary.